### PR TITLE
Support for SunPlus/GeneralPlus u'nSP architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,14 @@ src/dasm51
 src/dasm1802
 src/dasm7000
 src/dasm78k3
+src/dasm68k
 src/dasm85
 src/dasm96
 src/dasmavr
+src/dasmpic12
+src/dasmpic16
+src/dasmpic18
+src/dasmunsp
 src/dasmx86
 src/dasmz80
 .*.sw?

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Supported Processors:
   * Motorola 6805 family
   * Motorola 6809
   * NEC 78K/III (uPD78310 family)
+  * SunPlus µNSP
   * Texas Instruments TMS7000
   * Zilog Z80
   * RCA CDP1802

--- a/src/Makefile
+++ b/src/Makefile
@@ -142,7 +142,6 @@ dasm68k: ${D68K_OBJS}
 
 #################################################
 
-<<<<<<< HEAD
 DPIC12_OBJS = ${CORE_OBJS} decodepic12.o
 
 dasmpic12: ${DPIC12_OBJS}

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,6 +30,7 @@ TARGETS = dasm78k3$(X) \
           dasmpic12$(X)\
           dasmpic16$(X)\
           dasmpic18$(X)\
+          dasmunsp$(X)  \
           txt2bin$(X)
 
 CORE_OBJS = dasmxx.o xref.o optab.o
@@ -141,6 +142,7 @@ dasm68k: ${D68K_OBJS}
 
 #################################################
 
+<<<<<<< HEAD
 DPIC12_OBJS = ${CORE_OBJS} decodepic12.o
 
 dasmpic12: ${DPIC12_OBJS}
@@ -159,6 +161,13 @@ DPIC18_OBJS = ${CORE_OBJS} decodepic18.o
 
 dasmpic18: ${DPIC18_OBJS}
 	$(CC) ${DPIC18_OBJS} -o ${@}
+
+#################################################
+
+DUNSP_OBJS = ${CORE_OBJS} decodeunsp.o
+
+dasmunsp: ${DUNSP_OBJS}
+	$(CC) ${DUNSP_OBJS} -o ${@}
 
 #################################################
 
@@ -199,6 +208,7 @@ what:
 	@echo "     dasmpic12  -- Microchip PIC12"
 	@echo "     dasmpic16  -- Microchip PIC16"
 	@echo "     dasmpic18  -- Microchip PIC18"
+	@echo "     dasmunsp   -- SunPlus/GeneralPlus µ'nSP"
 	@echo ""
 
 #################################################

--- a/src/dasmxx.c
+++ b/src/dasmxx.c
@@ -383,7 +383,7 @@ static int emitaddr( ADDR addr, struct params *params )
     if ( !params->want_stripped )
         return printf( "%c   " FORMAT_ADDR ":    ", 
             params->want_asm_out ? ';' : ' ',
-            addr );
+            addr / 2);
     else
         return 0;
 }
@@ -514,6 +514,7 @@ static void readlist( const char *listfile, struct params *params )
                     unsigned int cmd_idx = strchr( datchars, cmd ) - datchars;
                     unsigned bytes_per_line = BYTES_PER_LINE;
                     sscanf( pbuf, "%x%n", &addr, &n );
+					addr *= 2;
                     pbuf += n;
                     
                     if ( *pbuf == ',' )
@@ -595,6 +596,7 @@ static void readlist( const char *listfile, struct params *params )
            case 'd':   /* Define xref data label */
                 {
                     sscanf( pbuf, "%x%n", &addr, &n );
+					addr *= 2;
                     pbuf += n;
                     
                     SKIP_SPACE(pbuf);
@@ -613,6 +615,7 @@ static void readlist( const char *listfile, struct params *params )
             case 'k':   /* Single-line (k)comment */
                 {
                     sscanf( pbuf, "%x%n", &addr, &n );
+					addr *= 2;
                     pbuf += n;
                     
                     SKIP_SPACE(pbuf);
@@ -624,6 +627,7 @@ static void readlist( const char *listfile, struct params *params )
             case 'n':   /* Multiple-line note */
                 {
                     sscanf( pbuf, "%x%n", &addr, &n );
+					addr *= 2;
                     pbuf += n;
                     
                     /* Initialise the note buffer and switch to LINE_NOTE mode. */

--- a/src/dasmxx.c
+++ b/src/dasmxx.c
@@ -383,7 +383,7 @@ static int emitaddr( ADDR addr, struct params *params )
     if ( !params->want_stripped )
         return printf( "%c   " FORMAT_ADDR ":    ", 
             params->want_asm_out ? ';' : ' ',
-            addr / 2);
+            addr / dasm_word_width_bytes);
     else
         return 0;
 }
@@ -514,7 +514,7 @@ static void readlist( const char *listfile, struct params *params )
                     unsigned int cmd_idx = strchr( datchars, cmd ) - datchars;
                     unsigned bytes_per_line = BYTES_PER_LINE;
                     sscanf( pbuf, "%x%n", &addr, &n );
-					addr *= 2;
+                    addr *= dasm_word_width_bytes;
                     pbuf += n;
                     
                     if ( *pbuf == ',' )
@@ -596,7 +596,7 @@ static void readlist( const char *listfile, struct params *params )
            case 'd':   /* Define xref data label */
                 {
                     sscanf( pbuf, "%x%n", &addr, &n );
-					addr *= 2;
+                    addr *= dasm_word_width_bytes;
                     pbuf += n;
                     
                     SKIP_SPACE(pbuf);
@@ -615,7 +615,7 @@ static void readlist( const char *listfile, struct params *params )
             case 'k':   /* Single-line (k)comment */
                 {
                     sscanf( pbuf, "%x%n", &addr, &n );
-					addr *= 2;
+                    addr *= dasm_word_width_bytes;
                     pbuf += n;
                     
                     SKIP_SPACE(pbuf);
@@ -627,7 +627,7 @@ static void readlist( const char *listfile, struct params *params )
             case 'n':   /* Multiple-line note */
                 {
                     sscanf( pbuf, "%x%n", &addr, &n );
-					addr *= 2;
+                    addr *= dasm_word_width_bytes;
                     pbuf += n;
                     
                     /* Initialise the note buffer and switch to LINE_NOTE mode. */

--- a/src/dasmxx.h
+++ b/src/dasmxx.h
@@ -108,14 +108,16 @@ extern const int    dasm_max_insn_length;
 extern const int    dasm_max_opcode_width;
 extern const int    dasm_word_msb_first;
 extern const int    dasm_insn_width_bytes;
+extern const int    dasm_word_width_bytes;
 
-#define DASM_PROFILE(name,desc,insnlen,opwid,msb,iwid) \
+#define DASM_PROFILE(name,desc,insnlen,opwid,msb,iwid,wwid) \
     const char * dasm_name = name;                /* Name of assembler     */ \
     const char * dasm_description = desc;         /* Target description    */ \
     const int    dasm_max_insn_length = insnlen;  /* Max bytes per insn    */ \
     const int    dasm_max_opcode_width = opwid;   /* Max chars insn name   */ \
     const int    dasm_word_msb_first = msb;       /* 1 if word is MSB first*/ \
-    const int    dasm_insn_width_bytes = iwid;    /* Num bytes per opcode  */
+    const int    dasm_insn_width_bytes = iwid;    /* Num bytes per opcode  */ \
+    const int    dasm_word_width_bytes = iwid;    /* Num bytes per word    */
 
 /*****************************************************************************/
 

--- a/src/decode02.c
+++ b/src/decode02.c
@@ -42,7 +42,7 @@
  * Globally-visible decoder properties
  *****************************************************************************/
 
-DASM_PROFILE( "dasm02", "MOS Technology 6502", 3, 9, 0, 1 )
+DASM_PROFILE( "dasm02", "MOS Technology 6502", 3, 9, 0, 1, 1 )
 
 /*****************************************************************************
  * Private data types, macros, constants.

--- a/src/decode05.c
+++ b/src/decode05.c
@@ -42,7 +42,7 @@
  * Globally-visible decoder properties
  *****************************************************************************/
 
-DASM_PROFILE( "dasm05", "Motorola 6805", 3, 9, 1, 1 )
+DASM_PROFILE( "dasm05", "Motorola 6805", 3, 9, 1, 1, 1 )
 
 /*****************************************************************************
  * Private data types, macros, constants.

--- a/src/decode09.c
+++ b/src/decode09.c
@@ -42,7 +42,7 @@
  * Globally-visible decoder properties
  *****************************************************************************/
 
-DASM_PROFILE( "dasm09", "Motorola 6809", 4, 9, 0, 1 )
+DASM_PROFILE( "dasm09", "Motorola 6809", 4, 9, 0, 1, 1 )
 
 /*****************************************************************************
  * Private data types, macros, constants.

--- a/src/decode1802.c
+++ b/src/decode1802.c
@@ -48,7 +48,7 @@
  * Globally-visible decoder properties
  *****************************************************************************/
 
-DASM_PROFILE( "dasm1802", "RCA CDP1802", 3, 9, 0, 1 )
+DASM_PROFILE( "dasm1802", "RCA CDP1802", 3, 9, 0, 1, 1 )
 
 /*****************************************************************************
  * Private data types, macros, constants.

--- a/src/decode48.c
+++ b/src/decode48.c
@@ -42,7 +42,7 @@
  * Globally-visible decoder properties
  *****************************************************************************/
 
-DASM_PROFILE( "dasm48", "Intel MCS-48 (8048, 8049)", 4, 9, 0, 1 )
+DASM_PROFILE( "dasm48", "Intel MCS-48 (8048, 8049)", 4, 9, 0, 1, 1 )
 
 /*****************************************************************************
  * Private data types, macros, constants.

--- a/src/decode51.c
+++ b/src/decode51.c
@@ -42,7 +42,7 @@
  * Globally-visible decoder properties
  *****************************************************************************/
 
-DASM_PROFILE( "dasm51", "Intel 8051", 4, 9, 0, 1 )
+DASM_PROFILE( "dasm51", "Intel 8051", 4, 9, 0, 1, 1 )
 
 /*****************************************************************************
  * Private data types, macros, constants.

--- a/src/decode68k.c
+++ b/src/decode68k.c
@@ -48,7 +48,7 @@
  * Globally-visible decoder properties
  *****************************************************************************/
 
-DASM_PROFILE( "dasm68k", "Motorola 68000", 22, 9, 1, 2 )
+DASM_PROFILE( "dasm68k", "Motorola 68000", 22, 9, 1, 2, 1 )
 
 /*****************************************************************************
  * Private data types, macros, constants.

--- a/src/decode7000.c
+++ b/src/decode7000.c
@@ -42,7 +42,7 @@
  * Globally-visible decoder properties
  *****************************************************************************/
 
-DASM_PROFILE( "dasm7000", "TI TMS7000", 4, 9, 1, 1 )
+DASM_PROFILE( "dasm7000", "TI TMS7000", 4, 9, 1, 1, 1 )
 
 /*****************************************************************************
  * Private data types, macros, constants.

--- a/src/decode78k3.c
+++ b/src/decode78k3.c
@@ -42,7 +42,7 @@
  * Gloabally-visible decoder properties
  *****************************************************************************/
 
-DASM_PROFILE( "dasm78k3", "NEC 78K/III", 5, 9, 0, 1 )
+DASM_PROFILE( "dasm78k3", "NEC 78K/III", 5, 9, 0, 1, 1 )
 
 /*****************************************************************************
  * Private data types, macros, constants.

--- a/src/decode85.c
+++ b/src/decode85.c
@@ -50,7 +50,7 @@
  * Globally-visible decoder properties
  *****************************************************************************/
 
-DASM_PROFILE( "dasm85", "Intel 8085", 4, 9, 0, 1 )
+DASM_PROFILE( "dasm85", "Intel 8085", 4, 9, 0, 1, 1 )
 
 /*****************************************************************************
  * Private data types, macros, constants.

--- a/src/decode96.c
+++ b/src/decode96.c
@@ -38,7 +38,7 @@
 #include "dasmxx.h"
 
 
-DASM_PROFILE( "dasm96", "Intel 8096", 8, 9, 0, 1 )
+DASM_PROFILE( "dasm96", "Intel 8096", 8, 9, 0, 1, 1 )
 
 
 static char * output_buffer = NULL;

--- a/src/decodeavr.c
+++ b/src/decodeavr.c
@@ -49,7 +49,7 @@
  * Globally-visible decoder properties
  *****************************************************************************/
 
-DASM_PROFILE( "dasmavr", "Atmel AVR", 4, 9, 0, 2 )
+DASM_PROFILE( "dasmavr", "Atmel AVR", 4, 9, 0, 2, 1 )
 
 /*****************************************************************************
  * Private data types, macros, constants.

--- a/src/decodepic12.c
+++ b/src/decodepic12.c
@@ -47,7 +47,7 @@
  * Globally-visible decoder properties
  *****************************************************************************/
 
-DASM_PROFILE( "dasmpic12", "Microchip PIC10/PIC12", 4, 9, 0, 2 )
+DASM_PROFILE( "dasmpic12", "Microchip PIC10/PIC12", 4, 9, 0, 2, 1 )
 
 /*****************************************************************************
  * Private data types, macros, constants.

--- a/src/decodepic16.c
+++ b/src/decodepic16.c
@@ -47,7 +47,7 @@
  * Globally-visible decoder properties
  *****************************************************************************/
 
-DASM_PROFILE( "dasmpic16", "Microchip PIC16", 4, 9, 0, 2 )
+DASM_PROFILE( "dasmpic16", "Microchip PIC16", 4, 9, 0, 2, 1 )
 
 /*****************************************************************************
  * Private data types, macros, constants.

--- a/src/decodepic18.c
+++ b/src/decodepic18.c
@@ -47,7 +47,7 @@
  * Globally-visible decoder properties
  *****************************************************************************/
 
-DASM_PROFILE( "dasmpic18", "Microchip PIC18", 4, 9, 0, 2 )
+DASM_PROFILE( "dasmpic18", "Microchip PIC18", 4, 9, 0, 2, 1 )
 
 /*****************************************************************************
  * Private data types, macros, constants.

--- a/src/decodeunsp.c
+++ b/src/decodeunsp.c
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2022 Adrien Destugues <pulkomandy@pulkomandy.tk>
+ *
+ * Distributed under terms of the MIT license.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdbool.h>
+
+#include "dasmxx.h"
+#include "optab.h"
+
+
+DASM_PROFILE( "dasmunsp", "SunPlus µnSP", 4, 5, 0, 2 )
+
+const char* const regname[] = { "SP", "R1", "R2", "R3", "R4", "BP", "SR", "PC" };
+
+#define OPB (opc & 7)
+#define OPN ((opc >> 3) & 7)
+#define OP1 ((opc >> 6) & 7)
+#define OPA ((opc >> 9) & 7)
+#define IMM6 (opc & 0x3F)
+
+OPERAND_FUNC(none)
+{
+}
+
+OPERAND_FUNC(int)
+{
+	const char* const intname[] = { "OFF", "IRQ", "FIQ", "IRQ,FIQ" };
+	operand( "%s", intname[OPB]);
+}
+
+OPERAND_FUNC(call)
+{
+	int target = (IMM6 << 16) | nextw(f, addr);
+	char buf[32];
+	operand( "%s", xref_genwordaddr(buf, "%08x", target));
+		;
+}
+
+OPERAND_FUNC(jmp)
+{
+	int dir = OP1;
+	int off = IMM6;
+	if (dir == 1) {
+		operand("%x", *addr / 2 - off);
+	} else if (dir == 0) {
+		operand("%x", *addr / 2 + off);
+	} else {
+		operand("?? unknown jump direction %d", dir);
+	}
+}
+
+OPERAND_FUNC(pushset)
+{
+	// OPA OPN Regs
+	// 1     1 R1
+	// 2     2 R1-R2
+	// 2     1 R2
+	// Rh to Rh-N, OPA encodes Rh
+	if ((OPA + 1) >= OPN)
+		operand("%s-%s", regname[OPA + 1 - OPN] , regname[OPA]);
+	else
+		operand("INVALID");
+}
+
+OPERAND_FUNC(popset)
+{
+	// Rl to Rl+N, OPA encodes Rl-1
+	if ((OPA + 1) > 7 || (OPA + OPN) > 7)
+		operand("INVALID");
+	else
+		operand("%s-%s", regname[OPA + 1] , regname[OPA + OPN]);
+}
+
+OPERAND_FUNC(stack)
+{
+    operand( "[%s]", regname[OPB]);
+}
+
+OPERAND_FUNC(op1)
+{
+    operand( "%s", regname[OPA]);
+}
+
+bool op3 = false;
+
+OPERAND_FUNC(op2)
+{
+	switch (OP1) {
+		case 0:
+			operand("[BP+%x]", IMM6);
+			break;
+		case 1:
+			operand("#%x", IMM6);
+			break;
+		case 3:
+		{
+			int opn = OPN;
+			int rs = OPB;
+			int word;
+			if (opn & 4)
+				operand("D:");
+			switch (opn & 3) {
+				case 0:
+					operand("[%s]", regname[rs]);
+					break;
+				case 1:
+					operand("[%s--]", regname[rs]);
+					break;
+				case 2:
+					operand("[%s++]", regname[rs]);
+					break;
+				default:
+					operand("?? unknown OP3 opn %d", opn);
+					break;
+			}
+			break;
+		}
+		case 4:
+		{
+			int opn = OPN;
+			int word;
+			switch (opn) {
+				case 0:
+					operand("%s", regname[OPB]);
+					break;
+				case 1:
+					if (op3) {
+						operand("%s, ", regname[OPB]);
+					}
+					word = nextw(f, addr);
+					operand("#%x", word);
+					break;
+				case 2:
+				case 3: // only for ST
+				{
+					word = nextw(f, addr);
+					char buf[32];
+					operand("[%s]", xref_genwordaddr(buf, "%04x", word));
+					break;
+				}
+				default:
+					operand("?? unknown OP4 opn %d", opn);
+					break;
+			}
+			break;
+		}
+		case 5:
+		{
+			int opn = OPN;
+			if (opn >= 4)
+				operand("%s LSR %d", regname[OPB], opn - 3);
+			else
+				operand("%s LSL %d", regname[OPB], opn + 1);
+			break;
+		}
+		default:
+			operand("?? unknown op1 %d", OP1);
+			break;
+	}
+}
+
+OPERAND_FUNC(op3)
+{
+	op3 = true;
+	operand_op2(f, addr, opc, xtype);
+	op3 = false;
+}
+
+OPERAND_FUNC(mul)
+{
+	operand("%s, %s", regname[OPA], regname[OPB]);
+}
+
+TWO_OPERAND(op1, op2)
+TWO_OPERAND(op1, op3)
+TWO_OPERAND(pushset, stack)
+TWO_OPERAND(popset, stack)
+
+optab_t base_optab[] = {
+
+	// Jumps
+	MASK( "JCC", jmp,     0xFF80, 0x0E00, X_JMP)
+	MASK( "JNZ", jmp,     0xFF80, 0x4E00, X_JMP)
+	MASK( "JZ",  jmp,     0xFF80, 0x5E00, X_JMP)
+	MASK( "JA",  jmp,     0xFF80, 0x9E00, X_JMP)
+	MASK( "JG",  jmp,     0xFF80, 0xBE00, X_JMP)
+	MASK( "JMP", jmp,     0xFF80, 0xEE00, X_JMP)
+
+	INSN( "RETF", none, 0x9A90, X_NONE)
+	INSN( "RETI", none, 0x9A98, X_NONE)
+	MASK( "POP",  popset_stack, 0xF1C0, 0x9080, X_NONE)
+	MASK( "PUSH", pushset_stack, 0xF1C0, 0xD080, X_NONE)
+
+	// ALU ops
+	MASK( "ADD",  op1_op3, 0xF000, 0x0000, X_NONE)
+	MASK( "ADC",  op1_op3, 0xF000, 0x1000, X_NONE)
+	MASK( "SUB",  op1_op3, 0xF000, 0x2000, X_NONE)
+	MASK( "SBC",  op1_op3, 0xF000, 0x3000, X_NONE)
+	MASK( "CMP",  op1_op3, 0xF000, 0x4000, X_NONE) // TODO should be only op3 for 3-operand variants?
+	MASK( "NEG",  op1_op2, 0xF000, 0x6000, X_NONE)
+	MASK( "XOR",  op1_op3, 0xF000, 0x8000, X_NONE)
+	MASK( "LD",   op1_op2, 0xF000, 0x9000, X_NONE)
+	MASK( "OR",   op1_op3, 0xF000, 0xA000, X_NONE)
+	MASK( "AND",  op1_op3, 0xF000, 0xB000, X_NONE)
+	MASK( "TEST", op3,     0xF000, 0xC000, X_NONE)
+	MASK( "ST",   op1_op2, 0xF000, 0xD000, X_NONE)
+
+	// Specials
+	MASK( "INT",  int,  0xF1FC, 0xF140, X_NONE)
+	MASK( "CALL", call, 0xF1C0, 0xF040, X_CALL)
+	MASK( "MULS", mul,  0xF1C8, 0xF108, X_NONE)
+	END
+};

--- a/src/decodeunsp.c
+++ b/src/decodeunsp.c
@@ -41,7 +41,6 @@ OPERAND_FUNC(call)
 	int target = (IMM6 << 16) | nextw(f, addr);
 	char buf[32];
 	operand( "%s", xref_genwordaddr(buf, "%08x", target));
-		;
 }
 
 OPERAND_FUNC(jmp)
@@ -126,7 +125,7 @@ OPERAND_FUNC(op2)
 					operand("[%s++]", regname[rs]);
 					break;
 				default:
-					operand("?? unknown OP3 opn %d", opn);
+					operand("[++%s]", regname[rs]);
 					break;
 			}
 			break;

--- a/src/decodeunsp.c
+++ b/src/decodeunsp.c
@@ -48,13 +48,21 @@ OPERAND_FUNC(jmp)
 {
 	int dir = OP1;
 	int off = IMM6;
+	char buf[32];
 	if (dir == 1) {
-		operand("%x", *addr / 2 - off);
+		operand("%s", xref_genwordaddr(buf, "%04x", *addr / 2 - off));
 	} else if (dir == 0) {
-		operand("%x", *addr / 2 + off);
+		operand("%s", xref_genwordaddr(buf, "%04x", *addr / 2 + off));
 	} else {
 		operand("?? unknown jump direction %d", dir);
 	}
+}
+
+OPERAND_FUNC(ljmp)
+{
+	char buf[32];
+	int word = nextw(f, addr);
+	operand("%s", xref_genwordaddr(buf, "%08x", word | (*addr / 2 & 0xFFFF0000)));
 }
 
 OPERAND_FUNC(pushset)
@@ -198,6 +206,7 @@ optab_t base_optab[] = {
 	INSN( "RETI", none, 0x9A98, X_NONE)
 	MASK( "POP",  popset_stack, 0xF1C0, 0x9080, X_NONE)
 	MASK( "PUSH", pushset_stack, 0xF1C0, 0xD080, X_NONE)
+	INSN( "LJMP", ljmp, 0x9F0F, X_JMP)
 
 	// ALU ops
 	MASK( "ADD",  op1_op3, 0xF000, 0x0000, X_NONE)

--- a/src/decodeunsp.c
+++ b/src/decodeunsp.c
@@ -13,8 +13,10 @@
 #include "dasmxx.h"
 #include "optab.h"
 
-
-DASM_PROFILE( "dasmunsp", "SunPlus µnSP", 4, 5, 0, 2 )
+/* Note: u'nSP is not able to address individual bytes at all.
+ * So dasm_word_width_bytes is set to 2, and only 16-bit words can be addressed.
+ */
+DASM_PROFILE( "dasmunsp", "SunPlus µnSP", 4, 5, 0, 2, 2 )
 
 const char* const regname[] = { "SP", "R1", "R2", "R3", "R4", "BP", "SR", "PC" };
 

--- a/src/decodex86.c
+++ b/src/decodex86.c
@@ -42,7 +42,7 @@
  * Globally-visible decoder properties
  *****************************************************************************/
 
-DASM_PROFILE( "dasmx86", "Intel x86", 5, 9, 0, 1 )
+DASM_PROFILE( "dasmx86", "Intel x86", 5, 9, 0, 1, 1 )
 
 /*****************************************************************************
  * Private data types, macros, constants.

--- a/src/decodez80.c
+++ b/src/decodez80.c
@@ -46,7 +46,7 @@
  * Globally-visible decoder properties
  *****************************************************************************/
 
-DASM_PROFILE( "dasmz80", "Zilog Z80", 4, 9, 0, 1 )
+DASM_PROFILE( "dasmz80", "Zilog Z80", 4, 9, 0, 1, 1 )
 
 /*****************************************************************************
  * Private data types, macros, constants.

--- a/src/xref.c
+++ b/src/xref.c
@@ -231,7 +231,7 @@ char * xref_findaddrlabel( ADDR addr )
 
 char * xref_genwordaddr( char * buf, const char * format, ADDR addr )
 {
-    char * label = xref_findaddrlabel( addr );
+    char * label = xref_findaddrlabel( addr * 2 );
 	 
     if ( label )
         return label;

--- a/src/xref.c
+++ b/src/xref.c
@@ -231,8 +231,8 @@ char * xref_findaddrlabel( ADDR addr )
 
 char * xref_genwordaddr( char * buf, const char * format, ADDR addr )
 {
-    char * label = xref_findaddrlabel( addr * 2 );
-	 
+    char * label = xref_findaddrlabel( addr * dasm_word_width_bytes );
+
     if ( label )
         return label;
     


### PR DESCRIPTION
This CPU core is used in various gaming consoles, including the VTech V.Smile and V.Smile Motion.

It is a bit unusual in that it doesn't allow to address individual bytes, only 16-bit words. A previous pull request was rejected because it broke other CPUs while implementing this. This version is modified and add an extra parameter to DASM_PROFILE to define how many 8-bit bytes there is in the smallest addressable unit on the architecture. So this time it should not break anything (all other architectures set this to 1, making the added code in dasmxx core all no-operations).

Let me know if these changes are acceptable now or if further work is needed. Thanks for this very useful and well-designed tool :)