### PR TITLE
Add a "skip" command to skip empty regions

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -49,9 +49,10 @@ Dump commands:
 
      aXXXX       alphanumeric dump
      bXXXX[,N]   byte dump (N bytes, default is 16)
+     mXXXX       bitmap (each byte is dumped as a string of # and . for 1 and 0 bits respectively)
      sXXXX       string dump
-     wXXXX       word dump
      vXXXX       vector address dump
+     wXXXX       word dump
 
 Code disassembly commands:
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -53,6 +53,7 @@ Dump commands:
      sXXXX       string dump
      vXXXX       vector address dump
      wXXXX       word dump
+     zXXXX       skip (emits a SKIP with the number of bytes). Source must already be 0-filled.
 
 Code disassembly commands:
 

--- a/src/dasmxx.c
+++ b/src/dasmxx.c
@@ -71,9 +71,10 @@
  * Dump commands:
  *      aXXXX       alphanumeric dump
  *      bXXXX[,N]   byte dump (N bytes, default is 16)
+ *      mXXXX       bitmap
  *      sXXXX       string dump
- *      wXXXX       word dump
  *      vXXXX       vector address dump
+ *      wXXXX       word dump
  *
  * Code disassembly commands:
  *      cXXXX       code disassembly starts at XXXX


### PR DESCRIPTION
Some assemblers will have a .defs (define space) or similar directive to do this.